### PR TITLE
fix: EMSEDT-253: Fish Data Not Accepted

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -134,6 +134,7 @@ model aqi_observed_properties {
   create_utc_timestamp       DateTime @db.Timestamp(6)
   update_user_id             String   @db.VarChar(200)
   update_utc_timestamp       DateTime @db.Timestamp(6)
+  result_type                String?  @db.VarChar(200)
 }
 
 model aqi_result_grade {

--- a/backend/src/aqi_api/aqi_api.service.ts
+++ b/backend/src/aqi_api/aqi_api.service.ts
@@ -567,7 +567,24 @@ export class AqiApiService {
         } catch (err) {
           this.logger.error(`API CALL TO ${dbTable} failed: `, err);
         }
-
+      case "aqi_observed_properties":
+        try {
+          let result = await this.prisma.aqi_observed_properties.findMany({
+            where: {
+              custom_id: queryParam,
+            },
+            select: {
+              result_type: true
+            }
+          });
+          if (result.length > 0) {
+            return result;
+          } else {
+            return null;
+          }
+        } catch (err) {
+          this.logger.error(`API CALL TO ${dbTable} failed: `, err);
+        }
       default:
         try {
           let result = await this.prisma[dbTable].findMany({

--- a/backend/src/cron-job/cron-job.service.ts
+++ b/backend/src/cron-job/cron-job.service.ts
@@ -558,7 +558,7 @@ export class CronJobService {
     return filterArray(entries);
   }
 
-  @Cron(CronExpression.EVERY_MINUTE) // every 2 hours
+  @Cron(CronExpression.EVERY_10_SECONDS) // every 2 hours
   private async beginFileValidation() {
     /*
     TODO:

--- a/migrations/sql/V1.2.9__new_observed_prop_column.sql
+++ b/migrations/sql/V1.2.9__new_observed_prop_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE enmods.aqi_observed_properties ADD COLUMN result_type VARCHAR(200) NULL;


### PR DESCRIPTION
Added new column of result type to observed properties. 
Updated validation to verify is result value is number or string based on OPs result type
Actual validation of valid values will be done by AQS observation API

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-158-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-158-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)