### PR TITLE
fix: EMSEDT-253: Fish Data

### DIFF
--- a/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
+++ b/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
@@ -1550,7 +1550,8 @@ export class FileParseValidateService {
 
     if (
       rowData.DataClassification == "LAB" ||
-      rowData.DataClassification == "SURROGATE_RESULT"
+      rowData.DataClassification == "SURROGATE_RESULT" ||
+      rowData.DataClassification == "FIELD_SURVEY"
     ) {
       cleanedRow.ObservationID = "";
       cleanedRow.FieldDeviceID = "";
@@ -1560,7 +1561,7 @@ export class FileParseValidateService {
       cleanedRow.ResultGrade = "Ungraded";
       cleanedRow.ResultStatus = "Preliminary";
       cleanedRow.ActivityID = "";
-      cleanedRow.ActivityName = concatActivityName; // TODO: this will need to uncommented after Jeremy is done testing
+      cleanedRow.ActivityName =  rowData.DataClassification !== "FIELD_SURVEY" ? concatActivityName : ""; // TODO: this will need to uncommented after Jeremy is done testing
 
       if (cleanedRow.QCType == "REGULAR") {
         // this is because AQI interprets a null value as REGULAR
@@ -1569,8 +1570,7 @@ export class FileParseValidateService {
     } else if (
       rowData.DataClassification == "FIELD_RESULT" ||
       rowData.DataClassification == "ACTIVITY_RESULT" ||
-      rowData.DataClassification == "VERTICAL_PROFILE" ||
-      rowData.DataClassification == "FIELD_SURVEY"
+      rowData.DataClassification == "VERTICAL_PROFILE" 
     ) {
       cleanedRow.ObservationID = "";
       cleanedRow.FieldFiltered = "";


### PR DESCRIPTION
fix to ensure field surveys have specimen name and no activity name

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-160-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-160-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)