### PR TITLE
fix: EMSEDT-253: Fish Data 

### DIFF
--- a/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
+++ b/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
@@ -1561,7 +1561,7 @@ export class FileParseValidateService {
       cleanedRow.ResultGrade = "Ungraded";
       cleanedRow.ResultStatus = "Preliminary";
       cleanedRow.ActivityID = "";
-      cleanedRow.ActivityName =  rowData.DataClassification !== "FIELD_SURVEY" ? concatActivityName : ""; // TODO: this will need to uncommented after Jeremy is done testing
+      cleanedRow.ActivityName =  rowData.DataClassification == "FIELD_SURVEY" ? concatActivityName + ";FS" : concatActivityName; // TODO: this will need to uncommented after Jeremy is done testing
 
       if (cleanedRow.QCType == "REGULAR") {
         // this is because AQI interprets a null value as REGULAR


### PR DESCRIPTION
appending FS to activity name for field surveys

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-164-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-164-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)