### PR TITLE
feat: EMSEDT-280: New column for Biological Life Stage

### DIFF
--- a/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
+++ b/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
@@ -77,6 +77,7 @@ const fileHeaders: FileHeaders = {
   "QC Type": "QC Type",
   "QC Source Activity Name": "QC Source Activity Name",
   "Composite Stat": "Composite Stat",
+  "Biological Life Stage": "Biological Life Stage"
 };
 
 const visits: FieldVisits = {
@@ -161,6 +162,7 @@ const observations: Observations = {
   QCSourceActivityName: "",
   LabBatchID: "",
   CompositeStat: "",
+  BiologicalLifeStage: ""
 };
 
 const obsFile: ObservationFile = {
@@ -204,6 +206,7 @@ const obsFile: ObservationFile = {
   "QC: Source Sample ID": "",
   "EA_Lab Batch ID": "",
   "EA_Observation Composite Stat": "",
+  "EA_Biological Life Stage": "",
   "EA_Upload File Name": "",
 };
 
@@ -231,9 +234,7 @@ export class FileParseValidateService {
   constructor(
     private prisma: PrismaService,
     private readonly fileSubmissionsService: FileSubmissionsService,
-    private readonly aqiService: AqiApiService,
-    private readonly objectStoreService: ObjectStoreService,
-    private readonly operationLockService: OperationLockService,
+    private readonly aqiService: AqiApiService
   ) {}
 
   async getQueuedFiles() {
@@ -2204,6 +2205,14 @@ export class FileParseValidateService {
         });
 
         rowData = await this.cleanRowBasedOnDataClassification(rowData);
+      }
+
+      if (!/^Animal - .+/.test(rowData["Medium"])){
+        rowData["EA_Biological Life Stage"] = ""
+      }
+
+      if ((rowData["DataClassification"] !== "LAB" && rowData["DataClassification"] !== "SURROGATE_RESULT" && rowData["DataClassification"] !== "FIELD_SURVEY")){
+        rowData["EA_Biological Life Stage"] = ""
       }
 
       this.logger.log(`Finished creating object for row ${rowNumber}`);

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -113,6 +113,7 @@ export type FileHeaders = {
   "QC Type": string;
   "QC Source Activity Name": string;
   "Composite Stat": string;
+  "Biological Life Stage": string
 };
 
 export type FieldVisits = {
@@ -197,6 +198,7 @@ export type Observations = {
   QCType: string;
   QCSourceActivityName: string;
   CompositeStat: string;
+  BiologicalLifeStage: string
 };
 
 export type ObservationFile = {
@@ -240,6 +242,7 @@ export type ObservationFile = {
   "QC: Type": string;
   "QC: Source Sample ID": string;
   "EA_Observation Composite Stat": string;
+  "EA_Biological Life Stage": string,
   "EA_Upload File Name": string;
 };
 


### PR DESCRIPTION
Added a new column for an observation extended attribute. The column goes at the end of the file as "Biological Life Stage" and will be appended to the observation file as "EA_Biological Life Stage" when being sent to the observation API

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-192-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-192-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)