### PR TITLE
fix: EMSEDT-279: Partial Uploads

### DIFF
--- a/backend/src/aqi_api/aqi_api.service.ts
+++ b/backend/src/aqi_api/aqi_api.service.ts
@@ -345,6 +345,8 @@ export class AqiApiService {
       }
     } catch (err) {
       this.logger.error("API call to Observation Import failed: ", err);
+      const errorLog = JSON.parse(`{"rowNum": "N/A", "type": "ERROR", "message": {"ObservationFile": "Observation API call to status/result failed. Please re-upload the file."}}`);
+      return [errorLog]
     }
   }
 
@@ -368,7 +370,7 @@ export class AqiApiService {
       },
     });
 
-    if (statusURL != null || statusURL != undefined) {
+    if (statusURL !== null && statusURL !== undefined) {
       try {
         const response = await axios.get(statusURL.status_url, {
           headers: {

--- a/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
+++ b/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
@@ -1510,6 +1510,8 @@ export class FileParseValidateService {
       observationsErrors,
     );
 
+    console.log(finalErrorLog)
+
     return finalErrorLog;
   }
 


### PR DESCRIPTION
This ticket addresses the following:

1. Update the field visit validation to ensure the GET method has the same information as the POST method
2. Updated the partial upload messages such that the user knows the cause of the partial upload (and rollback)
3. Updated handling of failed API call to AQS observation API. Now EDT will reject the file and include an error message in the log file.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-196-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-196-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)