### PR TITLE
fix: EMSEDT-302 - Tissue Type lookup failing

### DIFF
--- a/backend/src/file_submissions/file_submissions_api_key.controller.ts
+++ b/backend/src/file_submissions/file_submissions_api_key.controller.ts
@@ -96,7 +96,7 @@ export class FileSubmissionsAPIController {
       throw new BadRequestException('File has more than 10,000 rows')
     }
 
-    await this.fileSubmissionsService.createWithSftp(
+    await this.fileSubmissionsService.createWithSftp( 
       {
         userID: apiKeyRecord.username,
         orgGUID: null,


### PR DESCRIPTION
When entering invalid tissue type value, the system considers the file as an ERROR when it should be REJECTED.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-214-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-214-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)