### PR TITLE
fix: ENMODSEDT-11: Updated field visit ERROR message

### DIFF
--- a/backend/src/aqi_api/aqi_api.service.ts
+++ b/backend/src/aqi_api/aqi_api.service.ts
@@ -59,6 +59,7 @@ export class AqiApiService {
         id: rowNumber,
         url: url,
         count: response.data.totalCount,
+        visitStartTime: response.data.domainObjects.length > 0 ? response.data.domainObjects[0].startTime : '',
         error: null,
         GUID:
           response.data.domainObjects.length > 0
@@ -75,6 +76,7 @@ export class AqiApiService {
         id: rowNumber,
         url: url,
         count: 0,
+        visitStartTime: null,
         error: err.response.data.message,
         GUID: null,
       }

--- a/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
+++ b/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
@@ -1463,7 +1463,6 @@ export class FileParseValidateService {
       rowData["DataClassification"] === "SURROGATE_RESULT";
 
     if (!isLabData) {
-      console.log("returning");
       return errors;
     }
 
@@ -2386,6 +2385,7 @@ export class FileParseValidateService {
         let visitExistsForDay = false;
         let activityURL = `/v1/activities?samplingLocationIds=${locationGUID.samplingLocation.id}&fromStartTime=${encodedObservedDateTime}&toStartTime=${encodedObservedDateTime}&customId=${rowData.ActivityName}`;
         let activityExists = false;
+        let visitTimeForDay = null;
 
         this.logger.log(`visitUrlForDay: ${visitURLForDay}`);
         this.logger.log(`visitUrlForTime: ${visitURLForTime}`);
@@ -2404,6 +2404,7 @@ export class FileParseValidateService {
           );
           if (seenVisitUrlForDay.count > 0) {
             visitExistsForDay = true;
+            visitTimeForDay = seenVisitUrlForDay.visitStartTime;
             this.logger.log(
               `[Row ${rowNumber}] Day visit check - found ${seenVisitUrlForDay.count} existing visits for the day`,
             );
@@ -2420,6 +2421,7 @@ export class FileParseValidateService {
             rowNumber,
             visitURLForDay,
           );
+          visitTimeForDay = visitURLCalledForDay.visitStartTime;
           if (visitURLCalledForDay.error == null) {
             // this means no error in the api call
             if (visitURLCalledForDay.count > 0) {
@@ -2488,7 +2490,7 @@ export class FileParseValidateService {
                 rowNum: rowNumber,
                 type: "ERROR",
                 message: {
-                  Visit: `A field visit exists for Location ${rowData.LocationID} on this day, but not at the specified Start Time ${rowData.FieldVisitStartTime}. Please correct the date time and re-upload the file.`,
+                  Visit: `A field visit exists for Location ${rowData.LocationID} on this day, but not at the specified Start Time ${rowData.FieldVisitStartTime}. The existing field visit start time is ${visitTimeForDay}. Please correct the date time and re-upload the file.`,
                 },
               };
               errorLogs.push(errorLog);
@@ -2527,7 +2529,7 @@ export class FileParseValidateService {
                   rowNum: rowNumber,
                   type: "ERROR",
                   message: {
-                    Visit: `A field visit exists for Location ${rowData.LocationID} on this day, but not at the specified Start Time ${rowData.FieldVisitStartTime}. Please correct the date time and re-upload the file.`,
+                    Visit: `A field visit exists for Location ${rowData.LocationID} on this day, but not at the specified Start Time ${rowData.FieldVisitStartTime}. The existing field visit start time is ${visitTimeForDay}. Please correct the date time and re-upload the file.`,
                   },
                 };
                 errorLogs.push(errorLog);


### PR DESCRIPTION
This pull request primarily improves the accuracy and clarity of error messages related to field visit validation, and adds handling for visit start times in both the AQI API and file validation services. The changes ensure that users are informed of the actual existing visit start time when a mismatch occurs, making troubleshooting easier.

**Field Visit Validation and Error Messaging:**

* Updated error messages in `FileParseValidateService` to include the actual existing field visit start time (`visitTimeForDay`) when a visit exists for the day but not at the specified start time, providing clearer guidance to users. [[1]](diffhunk://#diff-c38b0a8fff2861f8facda7ce42d240f7a01ba39b04307b19a1ce060be8ff473aL2491-R2493) [[2]](diffhunk://#diff-c38b0a8fff2861f8facda7ce42d240f7a01ba39b04307b19a1ce060be8ff473aL2530-R2532)
* Introduced the `visitTimeForDay` variable to track the start time of an existing visit for the day, and set its value based on API responses. [[1]](diffhunk://#diff-c38b0a8fff2861f8facda7ce42d240f7a01ba39b04307b19a1ce060be8ff473aR2388) [[2]](diffhunk://#diff-c38b0a8fff2861f8facda7ce42d240f7a01ba39b04307b19a1ce060be8ff473aR2407) [[3]](diffhunk://#diff-c38b0a8fff2861f8facda7ce42d240f7a01ba39b04307b19a1ce060be8ff473aR2424)

**AQI API Enhancements:**

* Modified `AqiApiService` to include `visitStartTime` in API responses, setting it based on the first domain object's start time or as `null`/empty string in error cases, for consistency and downstream usage. [[1]](diffhunk://#diff-60578abc788dc082b769da617461cba5097ac2e751b066facb025778ad9ce752R62) [[2]](diffhunk://#diff-60578abc788dc082b769da617461cba5097ac2e751b066facb025778ad9ce752R79)

**Code Cleanliness:**

* Removed an unnecessary `console.log` statement from the lab data validation logic for cleaner output.

<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-dar-311-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-dar-311-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-dar/actions/workflows/merge.yml)