### PR TITLE
ENMODSEDT-11: improve field visit error messages

### DIFF
--- a/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
+++ b/backend/src/file_parse_and_validation/file_parse_and_validation.service.ts
@@ -2375,13 +2375,15 @@ export class FileParseValidateService {
 
         // Extract YYYY-MM-DD from FieldVisitStartTime and append time components
         const datePart = rowData.FieldVisitStartTime.split("T")[0]; // Extract YYYY-MM-DD part
+        const match = rowData.FieldVisitStartTime.match(/([+-]\d{2}:\d{2})$/);
+        const timeZone = match ? match[1] : "-07:00"; // Default to -07:00 if no timezone found
         const encodedVisitStartTime = encodeURIComponent(
           rowData.FieldVisitStartTime,
         );
         const encodedObservedDateTime = encodeURIComponent(
           rowData.ObservedDateTime,
         );
-        const visitURLForDay = `/v1/fieldvisits?samplingLocationIds=${locationGUID.samplingLocation.id}&start-startTime=${datePart}T00:00:00-08:00&end-startTime=${datePart}T23:59:59-08:00`;
+        const visitURLForDay = `/v1/fieldvisits?samplingLocationIds=${locationGUID.samplingLocation.id}&start-startTime=${datePart}T00:00:00${timeZone}&end-startTime=${datePart}T23:59:59${timeZone}`;
         const visitURLForTime = `/v1/fieldvisits?samplingLocationIds=${locationGUID.samplingLocation.id}&start-startTime=${encodedVisitStartTime}&end-startTime=${encodedVisitStartTime}`;
         let visitExists = false;
         let visitExistsForDay = false;


### PR DESCRIPTION
This pull request updates how time zone offsets are handled when constructing API query URLs for field visit data. The main improvement is that the service now dynamically extracts the time zone from the `FieldVisitStartTime` value, ensuring more accurate queries for visits on a specific day.

**Field visit URL construction improvements:**

* The code now parses the time zone offset from `rowData.FieldVisitStartTime` using a regular expression, defaulting to `-07:00` if none is found. This offset is then used when building the `visitURLForDay` string, replacing the previously hardcoded `-08:00` value.<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.
This pull request updates the way time zone offsets are handled when constructing URLs for field visit queries. The main improvement is that the time zone is now dynamically extracted from the `FieldVisitStartTime` value, rather than being hardcoded.

Improvements to time zone handling:

* The code now extracts the time zone offset from `rowData.FieldVisitStartTime` using a regular expression. If no time zone is found, it defaults to `-07:00`. This ensures that the correct time zone is used for each record.
* The `visitURLForDay` now incorporates the extracted (or defaulted) time zone offset, instead of always using `-08:00`. This makes the API queries more accurate for records with varying time zones.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
